### PR TITLE
Pull request for add-stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Contains docker-compose file to setup wazo-platform project
 
 ## Prepare Environment
 
+* `for repo in wazo-asterisk-config wazo-auth-keys xivo-manage-db; do git -C "$LOCAL_GIT_REPOS/$repo" pull; done`
 * `docker-compose pull --ignore-pull-failures`
 * `docker-compose build --pull`
 

--- a/bin/init-bootstrap
+++ b/bin/init-bootstrap
@@ -32,7 +32,7 @@ for n in range(retry):
             continue
         else:
             raise
-    print(r.text)
+    print(f'Response: {r}')
     break
 EOF
 
@@ -51,7 +51,7 @@ for n in range(retry):
             continue
         else:
             raise
-    print(r.text)
+    print(f'Response: {r}')
     break
 EOF
 
@@ -70,7 +70,7 @@ for n in range(retry):
             continue
         else:
             raise
-    print(r)
+    print(f'Response: {r}')
     break
 EOF
 
@@ -121,10 +121,12 @@ for n in range(retry):
             continue
         else:
             raise
-    print(r)
+    print(f'Response: {r}')
     break
 EOF
 
   echo Creating first tenant...
   wazo-auth-cli tenant create $TENANT_NAME
 fi
+
+echo Successfully bootstrapped !

--- a/bin/init-bootstrap
+++ b/bin/init-bootstrap
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
+container_timeout=${INIT_TIMEOUT:-60}
+
 function wait_for_wazo_auth() {
     seconds=0
-    timeout=30
-    while [ "$seconds" -lt "$timeout" ] && ! wazo-auth-cli user list > /dev/null
+    while [ "$seconds" -lt "$container_timeout" ] && ! wazo-auth-cli user list > /dev/null
       do
         echo -n .
         seconds=$((seconds+1))
@@ -19,10 +20,10 @@ echo Generating or updating service users...
 wazo-auth-keys service update
 
 echo Waiting for wazo-confd...
-python - <<'EOF'
+python - <<EOF
 import requests, time
 url = 'http://confd:9486/1.1/infos'
-retry = 60
+retry = $container_timeout
 delay = 1
 for n in range(retry):
     try:
@@ -38,10 +39,10 @@ for n in range(retry):
 EOF
 
 echo Waiting for wazo-provd...
-python - <<'EOF'
+python - <<EOF
 import requests, time
 url = 'http://provd:8666/0.2/status'
-retry = 60
+retry = $container_timeout
 delay = 1
 for n in range(retry):
     try:
@@ -57,10 +58,10 @@ for n in range(retry):
 EOF
 
 echo Waiting for wazo-sysconfd...
-python - <<'EOF'
+python - <<EOF
 import requests, time
 url = 'http://sysconfd:8668/status-check'
-retry = 60
+retry = $container_timeout
 delay = 1
 for n in range(retry):
     try:
@@ -108,10 +109,10 @@ if [[ ! $(wazo-auth-cli tenant show $TENANT_NAME) = *$TENANT_NAME* ]]; then
 
 
   echo "Waiting for wazo-webhookd (initializing amqp exchanges)..."
-  python - <<'EOF'
+  python - <<EOF
 import requests, time
 url = 'http://webhookd:9300/1.0/status'
-retry = 60
+retry = $container_timeout
 delay = 1
 for n in range(retry):
     try:

--- a/bin/init-bootstrap
+++ b/bin/init-bootstrap
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 function wait_for_wazo_auth() {
     seconds=0

--- a/bin/init-bootstrap
+++ b/bin/init-bootstrap
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -x
 
 function wait_for_wazo_auth() {
     seconds=0

--- a/bin/init-helpers
+++ b/bin/init-helpers
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
+timeout=${INIT_TIMEOUT:-60}
+
 function wait_for_service () {
   host=$1
   port=$2
-  timeout=${3:-60}
   seconds=0
   while [ "$seconds" -lt "$timeout" ] && ! nc -z -w1 $host $port
   do
@@ -19,7 +20,6 @@ function wait_for_service () {
 
 function wait_for_file(){
   key_file=$1
-  timeout=${2:-60}
   seconds=0
   while [ "$seconds" -lt "$timeout" ] && [ ! -f $key_file ]
   do

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
       - 9486
     environment:
       XIVO_UUID: "00000000-0000-4000-8000-0000000AA450"
+      INIT_TIMEOUT: 60
     volumes:
       - ./etc/wazo-confd.yml:/etc/wazo-confd/conf.d/config.yml:ro
       - ./etc/xivo-dao.yml:/etc/xivo-dao/conf.d/config.yml:ro
@@ -64,6 +65,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile-provd
+    environment:
+      INIT_TIMEOUT: 60
     ports:
       - 8666
     volumes:
@@ -89,6 +92,7 @@ services:
       - 9300
     environment:
       XIVO_UUID: "00000000-0000-4000-8000-0000000AA450"
+      INIT_TIMEOUT: 60
     volumes:
       - ./etc/wazo-webhookd.yml:/etc/wazo-webhookd/conf.d/config.yml:ro
       - ./bin/init-webhookd:/bin/wazo-webhookd/init:ro
@@ -134,6 +138,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile-bootstrap
+    environment:
+      INIT_TIMEOUT: 60
     volumes:
       - ./bin/init-bootstrap:/bin/platform-bootstrap/init:ro
       - ./etc/wazo-auth-cli.yml:/etc/wazo-auth-cli/conf.d/config.yml:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,4 +146,4 @@ volumes:
   pgdata:
   wazo-auth-keys:
   asterisk-doc:
-  tmp-rabbitmq:
+  tmp-rabbitmq:   # Compatibility for non-Linux systems

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       - 9486
     environment:
       XIVO_UUID: "00000000-0000-4000-8000-0000000AA450"
-      INIT_TIMEOUT: 60
+      INIT_TIMEOUT: 120
     volumes:
       - ./etc/wazo-confd.yml:/etc/wazo-confd/conf.d/config.yml:ro
       - ./etc/xivo-dao.yml:/etc/xivo-dao/conf.d/config.yml:ro
@@ -66,7 +66,7 @@ services:
       context: .
       dockerfile: Dockerfile-provd
     environment:
-      INIT_TIMEOUT: 60
+      INIT_TIMEOUT: 120
     ports:
       - 8666
     volumes:
@@ -92,7 +92,7 @@ services:
       - 9300
     environment:
       XIVO_UUID: "00000000-0000-4000-8000-0000000AA450"
-      INIT_TIMEOUT: 60
+      INIT_TIMEOUT: 120
     volumes:
       - ./etc/wazo-webhookd.yml:/etc/wazo-webhookd/conf.d/config.yml:ro
       - ./bin/init-webhookd:/bin/wazo-webhookd/init:ro
@@ -139,7 +139,7 @@ services:
       context: .
       dockerfile: Dockerfile-bootstrap
     environment:
-      INIT_TIMEOUT: 60
+      INIT_TIMEOUT: 120
     volumes:
       - ./bin/init-bootstrap:/bin/platform-bootstrap/init:ro
       - ./etc/wazo-auth-cli.yml:/etc/wazo-auth-cli/conf.d/config.yml:ro


### PR DESCRIPTION
## add comment about tmp-rabbitmq volume


## do not print bootstrap script

why: it's harder to debug with all echo and results
Anyways each step should have it's own "echo" line to explain what we do

## improve bootstrap output


## fail bootstrap on first fail

why: easier to debug and traceback not lost

## extract timeout to env variable

why: easier to change

## increase init_timeout to 120

why: on mac M1, container run on qemu and can be slow to start