### PR TITLE
Pull request for improve-docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ Contains docker-compose file to setup wazo-platform project
 * Clone the following repositories
     * wazo-platform/wazo-auth-keys
     * wazo-platform/xivo-manage-db
+    * wazo-platform/wazo-webhookd
 * set environment variable `LOCAL_GIT_REPOS=<path/to/cloned/repositories>`
 
 ## Prepare Environment
 
-* `for repo in wazo-auth-keys xivo-manage-db; do git -C "$LOCAL_GIT_REPOS/$repo" pull; done`
+* `for repo in wazo-webhookd wazo-auth-keys xivo-manage-db; do git -C "$LOCAL_GIT_REPOS/$repo" pull; done`
 * `docker-compose pull --ignore-pull-failures`
 * `docker-compose build --pull`
 

--- a/README.md
+++ b/README.md
@@ -8,14 +8,13 @@ Contains docker-compose file to setup wazo-platform project
 
 * Install docker and docker-compose
 * Clone the following repositories
-    * wazo-platform/wazo-asterisk-config
     * wazo-platform/wazo-auth-keys
     * wazo-platform/xivo-manage-db
 * set environment variable `LOCAL_GIT_REPOS=<path/to/cloned/repositories>`
 
 ## Prepare Environment
 
-* `for repo in wazo-asterisk-config wazo-auth-keys xivo-manage-db; do git -C "$LOCAL_GIT_REPOS/$repo" pull; done`
+* `for repo in wazo-auth-keys xivo-manage-db; do git -C "$LOCAL_GIT_REPOS/$repo" pull; done`
 * `docker-compose pull --ignore-pull-failures`
 * `docker-compose build --pull`
 

--- a/bin/init-asterisk
+++ b/bin/init-asterisk
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -x
+
+# Allow wazo-confd to write file 05-autoprov-wizard.conf
+chown asterisk:www-data /etc/asterisk/pjsip.d
+chmod 770 /etc/asterisk/pjsip.d
+
+asterisk -fTvvv

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,7 @@ services:
       - ./bin/init-confd:/bin/wazo-confd/init:ro
       - ./bin/init-helpers:/var/lib/wazo/helpers:ro
       - wazo-auth-keys:/var/lib/wazo-auth-keys:ro
+      - asterisk-autoprov:/etc/asterisk/pjsip.d:rw  # write 05-autoprov-wizard.conf
       - asterisk-doc:/var/lib/wazo-confd/asterisk-doc:ro
       - type: bind
         source: ${LOCAL_GIT_REPOS}/xivo-manage-db
@@ -121,8 +122,11 @@ services:
     volumes:
       - ./etc/asterisk-modules.conf:/etc/asterisk/modules.conf:ro
       - ./etc/asterisk-http.conf:/etc/asterisk/http.d/02-http.conf:ro
+      - ./bin/init-asterisk:/bin/asterisk/init:ro
+      - asterisk-autoprov:/etc/asterisk/pjsip.d:rw
       - asterisk-doc:/usr/share/asterisk/documentation:rw
-    command: "asterisk -fTvvv"
+    entrypoint:
+      - /bin/asterisk/init
 
   confgend:
     image: wazoplatform/wazo-confgend
@@ -159,5 +163,6 @@ services:
 volumes:
   pgdata:
   wazo-auth-keys:
+  asterisk-autoprov:
   asterisk-doc:
   tmp-rabbitmq:   # Compatibility for non-Linux systems

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,22 +122,6 @@ services:
       - ./etc/asterisk-modules.conf:/etc/asterisk/modules.conf:ro
       - ./etc/asterisk-http.conf:/etc/asterisk/http.d/02-http.conf:ro
       - asterisk-doc:/usr/share/asterisk/documentation
-      - type: bind
-        source: ${LOCAL_GIT_REPOS}/wazo-asterisk-config/etc/asterisk/ari.conf
-        target: /etc/asterisk/ari.conf
-        read_only: true
-      - type: bind
-        source: ${LOCAL_GIT_REPOS}/wazo-asterisk-config/etc/asterisk/ari.d
-        target: /etc/asterisk/ari.d
-        read_only: true
-      - type: bind
-        source: ${LOCAL_GIT_REPOS}/wazo-asterisk-config/etc/asterisk/http.conf
-        target: /etc/asterisk/http.conf
-        read_only: true
-      - type: bind
-        source: ${LOCAL_GIT_REPOS}/wazo-asterisk-config/etc/asterisk/http.d/01-wazo.conf
-        target: /etc/asterisk/http.d/01-wazo.conf
-        read_only: true
     command: "asterisk -fTvvv"
 
   confgend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       - ./bin/init-confd:/bin/wazo-confd/init:ro
       - ./bin/init-helpers:/var/lib/wazo/helpers:ro
       - wazo-auth-keys:/var/lib/wazo-auth-keys:ro
-      - asterisk-doc:/var/lib/wazo-confd/asterisk-doc
+      - asterisk-doc:/var/lib/wazo-confd/asterisk-doc:ro
       - type: bind
         source: ${LOCAL_GIT_REPOS}/xivo-manage-db
         target: /usr/share/xivo-manage-db
@@ -121,7 +121,7 @@ services:
     volumes:
       - ./etc/asterisk-modules.conf:/etc/asterisk/modules.conf:ro
       - ./etc/asterisk-http.conf:/etc/asterisk/http.d/02-http.conf:ro
-      - asterisk-doc:/usr/share/asterisk/documentation
+      - asterisk-doc:/usr/share/asterisk/documentation:rw
     command: "asterisk -fTvvv"
 
   confgend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,10 @@ services:
     volumes:
       - ./etc/wazo-auth.yml:/etc/wazo-auth/conf.d/config.yml:ro
       - ./bin/init-helpers:/var/lib/wazo/helpers:ro
-      - ${LOCAL_GIT_REPOS}/wazo-auth-keys/etc/wazo-auth/conf.d/50-wazo-default-policies.yml:/etc/wazo-auth/conf.d/50-wazo-default-policies.yml:ro
+      - type: bind
+        source: ${LOCAL_GIT_REPOS}/wazo-auth-keys/etc/wazo-auth/conf.d/50-wazo-default-policies.yml
+        target: /etc/wazo-auth/conf.d/50-wazo-default-policies.yml
+        read_only: true
 
   confd:
     image: wazoplatform/wazo-confd:manage-db
@@ -55,8 +58,11 @@ services:
       - ./bin/init-confd:/bin/wazo-confd/init:ro
       - ./bin/init-helpers:/var/lib/wazo/helpers:ro
       - wazo-auth-keys:/var/lib/wazo-auth-keys:ro
-      - ${LOCAL_GIT_REPOS}/xivo-manage-db:/usr/share/xivo-manage-db:ro
       - asterisk-doc:/var/lib/wazo-confd/asterisk-doc
+      - type: bind
+        source: ${LOCAL_GIT_REPOS}/xivo-manage-db
+        target: /usr/share/xivo-manage-db
+        read_only: true
     entrypoint:
       - /bin/wazo-confd/init
 
@@ -98,7 +104,10 @@ services:
       - ./bin/init-webhookd:/bin/wazo-webhookd/init:ro
       - ./bin/init-helpers:/var/lib/wazo/helpers:ro
       - wazo-auth-keys:/var/lib/wazo-auth-keys:ro
-      - ${LOCAL_GIT_REPOS}/wazo-webhookd:/usr/src/wazo-webhookd:ro  # include alembic scripts
+      - type: bind
+        source: ${LOCAL_GIT_REPOS}/wazo-webhookd
+        target: /usr/src/wazo-webhookd  # include alembic script
+        read_only: true
     entrypoint:
       - /bin/wazo-webhookd/init
 
@@ -112,11 +121,23 @@ services:
     volumes:
       - ./etc/asterisk-modules.conf:/etc/asterisk/modules.conf:ro
       - ./etc/asterisk-http.conf:/etc/asterisk/http.d/02-http.conf:ro
-      - ${LOCAL_GIT_REPOS}/wazo-asterisk-config/etc/asterisk/ari.conf:/etc/asterisk/ari.conf:ro
-      - ${LOCAL_GIT_REPOS}/wazo-asterisk-config/etc/asterisk/ari.d:/etc/asterisk/ari.d:ro
-      - ${LOCAL_GIT_REPOS}/wazo-asterisk-config/etc/asterisk/http.conf:/etc/asterisk/http.conf:ro
-      - ${LOCAL_GIT_REPOS}/wazo-asterisk-config/etc/asterisk/http.d/01-wazo.conf:/etc/asterisk/http.d/01-wazo.conf:ro
       - asterisk-doc:/usr/share/asterisk/documentation
+      - type: bind
+        source: ${LOCAL_GIT_REPOS}/wazo-asterisk-config/etc/asterisk/ari.conf
+        target: /etc/asterisk/ari.conf
+        read_only: true
+      - type: bind
+        source: ${LOCAL_GIT_REPOS}/wazo-asterisk-config/etc/asterisk/ari.d
+        target: /etc/asterisk/ari.d
+        read_only: true
+      - type: bind
+        source: ${LOCAL_GIT_REPOS}/wazo-asterisk-config/etc/asterisk/http.conf
+        target: /etc/asterisk/http.conf
+        read_only: true
+      - type: bind
+        source: ${LOCAL_GIT_REPOS}/wazo-asterisk-config/etc/asterisk/http.d/01-wazo.conf
+        target: /etc/asterisk/http.d/01-wazo.conf
+        read_only: true
     command: "asterisk -fTvvv"
 
   confgend:
@@ -143,8 +164,11 @@ services:
     volumes:
       - ./bin/init-bootstrap:/bin/platform-bootstrap/init:ro
       - ./etc/wazo-auth-cli.yml:/etc/wazo-auth-cli/conf.d/config.yml:ro
-      - ${LOCAL_GIT_REPOS}/wazo-auth-keys/etc/wazo-auth-keys/config.yml:/etc/wazo-auth-keys/config.yml:ro
       - wazo-auth-keys:/var/lib/wazo-auth-keys:rw
+      - type: bind
+        source: ${LOCAL_GIT_REPOS}/wazo-auth-keys/etc/wazo-auth-keys/config.yml
+        target: /etc/wazo-auth-keys/config.yml
+        read_only: true
     entrypoint:
       - /bin/platform-bootstrap/init
 

--- a/verify.sh
+++ b/verify.sh
@@ -76,7 +76,7 @@ fi
 echo 'SUCCEED'
 
 echo -n 'Validating wazo-webhookd status... '
-PROVD_STATUS=$(curl \
+WEBHOOKD_STATUS=$(curl \
   --insecure \
   --silent \
   --show-error \
@@ -85,11 +85,11 @@ PROVD_STATUS=$(curl \
   --header "X-Auth-Token: $TOKEN" \
   'https://localhost:8443/api/webhookd/1.0/status')
 
-if [ $(echo $PROVD_STATUS | jq --raw-output .bus_consumer.status) != 'ok' ]; then
+if [ $(echo $WEBHOOKD_STATUS | jq --raw-output .bus_consumer.status) != 'ok' ]; then
   echo 'FAILED (bus_consume)'
   exit 1
 fi
-if [ $(echo $PROVD_STATUS | jq --raw-output .master_tenant.status) != 'ok' ]; then
+if [ $(echo $WEBHOOKD_STATUS | jq --raw-output .master_tenant.status) != 'ok' ]; then
   echo 'FAILED (master_tenant)'
   exit 1
 fi

--- a/zuul.d/docker-run.yaml
+++ b/zuul.d/docker-run.yaml
@@ -1,11 +1,6 @@
 ---
 - hosts: all
   tasks:
-    - name: clone wazo-asterisk-config
-      command: "git clone https://github.com/wazo-platform/wazo-asterisk-config.git"
-      args:
-        chdir: "{{ zuul.project.src_dir }}"
-
     - name: clone wazo-auth-key
       command: "git clone https://github.com/wazo-platform/wazo-auth-keys.git"
       args:

--- a/zuul.d/docker-run.yaml
+++ b/zuul.d/docker-run.yaml
@@ -11,6 +11,11 @@
       args:
         chdir: "{{ zuul.project.src_dir }}"
 
+    - name: clone wazo-webhookd
+      command: "git clone https://github.com/wazo-platform/wazo-webhookd.git"
+      args:
+        chdir: "{{ zuul.project.src_dir }}"
+
     - name: Pull images
       command: "docker-compose pull --ignore-pull-failures"
       args:


### PR DESCRIPTION
## use long syntax for bind mount

why: long syntax will raise an error if source directory doesn't exist
short syntax will create source directory if not exists

Then if someone forget to clone a repo of wrongly define
LOCAL_GIT_REPOS, we want to raise an error and not create root:root
directory ...

## remove wazo-asterisk-config dependency

why: asterisk container already contains all default wazo configuration

## set read-only on asterisk-doc bind

why: no need to have rw permission

## write autoprov config file to asterisk config

why: allow to complete wizard without error and populate the autoprov
file