### PR TITLE
mitigate race condition on initialization

### DIFF
--- a/bin/init-helpers
+++ b/bin/init-helpers
@@ -15,6 +15,8 @@ function wait_for_service () {
   if [ "$seconds" -ge "$timeout" ]; then
     exit 1
   fi
+
+  sleep 2  # Try to fill delay between port is open and initialization is complete
 }
 
 


### PR DESCRIPTION
why: port can be openned but initialization not completed
note: On other services, this logic is handled inside service, that's
why sleep is good enough method for now, until we refactor chatd
database init