### PR TITLE
remove app_meetme from noload

### DIFF
--- a/etc/wazo-confgend.yml
+++ b/etc/wazo-confgend.yml
@@ -5,6 +5,5 @@ db_uri: postgresql://asterisk:secret@postgres/wazo
 
 enabled_asterisk_modules:
   # Remove error log from asterisk
-  app_meetme.so: false
   res_prometheus.so: false
   res_timing_dahdi: false


### PR DESCRIPTION
why: this modules is not enabled anymore by default in
wazoplatform/asterisk image