### PR TITLE
provd: add bus config

### DIFF
--- a/etc/wazo-provd.yml
+++ b/etc/wazo-provd.yml
@@ -9,3 +9,6 @@ auth:
 
 amid:
   host: amid
+
+bus:
+  host: rabbitmq


### PR DESCRIPTION
why: was not linked to bus when wazo-docker was created