### PR TITLE
etc/wazo-auth.yml: remove ldap_user disable

### DIFF
--- a/etc/wazo-auth.yml
+++ b/etc/wazo-auth.yml
@@ -7,9 +7,6 @@ db_uri: postgresql://asterisk:secret@postgres/wazo
 amqp:
   uri: amqp://guest:guest@rabbitmq:5672/
 
-enabled_backend_plugins:
-  ldap_user: false
-
 default_user_policy: null
 
 service_discovery:


### PR DESCRIPTION
why: ldap migrated to idp, ldap_user required for idp, current impl. works
