### PR TITLE
WAZO-2470-remove-hardcoded-asterisk

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ a local folder with the following steps:
 ## Troubleshooting
 
 - A good starting point for debugging is the `bootstrap` container log
-- To get sql prompt: `docker compose exec postgres psql -U asterisk wazo`
+- To get sql prompt: `docker compose exec postgres psql -U wazo wazo`
 - To use wazo-auth-cli: `docker compose run --entrypoint bash bootstrap`
 - To update only one service without restarting everything
 

--- a/bin/init-chatd
+++ b/bin/init-chatd
@@ -6,7 +6,7 @@ source /var/lib/wazo/helpers
 db_host='postgres'
 db_port='5432'
 db_name='wazo'
-db_username='asterisk'
+db_username='wazo'
 db_password='secret'
 db_uri="postgresql://$db_username:$db_password@$db_host:$db_port"
 

--- a/bin/init-confd
+++ b/bin/init-confd
@@ -6,7 +6,7 @@ source /var/lib/wazo/helpers
 db_host='postgres'
 db_port='5432'
 db_name='wazo'
-db_username='asterisk'
+db_username='wazo'
 db_password='secret'
 db_uri="postgresql://$db_username:$db_password@$db_host:$db_port"
 

--- a/bin/init-dird
+++ b/bin/init-dird
@@ -6,7 +6,7 @@ source /var/lib/wazo/helpers
 db_host='postgres'
 db_port='5432'
 db_name='wazo'
-db_username='asterisk'
+db_username='wazo'
 db_password='secret'
 db_uri="postgresql://$db_username:$db_password@$db_host:$db_port"
 

--- a/bin/init-webhookd
+++ b/bin/init-webhookd
@@ -6,7 +6,7 @@ source /var/lib/wazo/helpers
 db_host='postgres'
 db_port='5432'
 db_name='wazo'
-db_username='asterisk'
+db_username='wazo'
 db_password='secret'
 db_uri="postgresql://$db_username:$db_password@$db_host:$db_port"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     image: postgres:13  # Must use compatible version than the odbc_postgresql installed in asterisk container
     environment:
       POSTGRES_DB: wazo
-      POSTGRES_USER: asterisk  # reason: hardcoded in populate.sql
+      POSTGRES_USER: wazo
       POSTGRES_PASSWORD: secret
     env_file:
       - variables.env

--- a/etc/asterisk-res_odbc.conf
+++ b/etc/asterisk-res_odbc.conf
@@ -1,3 +1,3 @@
 [xivo](+)
-username => asterisk
+username => wazo
 password => secret

--- a/etc/wazo-agentd.yml
+++ b/etc/wazo-agentd.yml
@@ -2,7 +2,7 @@ debug: true
 rest_api:
   listen: 0.0.0.0
 
-db_uri: postgresql://asterisk:secret@postgres/wazo
+db_uri: postgresql://wazo:secret@postgres/wazo
 
 amid:
   host: amid

--- a/etc/wazo-agid.yml
+++ b/etc/wazo-agid.yml
@@ -1,7 +1,7 @@
 debug: true
 listen_address: 0.0.0.0
 
-db_uri: postgresql://asterisk:secret@postgres/wazo
+db_uri: postgresql://wazo:secret@postgres/wazo
 
 agentd:
   host: NOT-IMPLEMENTED

--- a/etc/wazo-auth.yml
+++ b/etc/wazo-auth.yml
@@ -2,7 +2,7 @@ debug: true
 rest_api:
   listen: 0.0.0.0
 
-db_uri: postgresql://asterisk:secret@postgres/wazo
+db_uri: postgresql://wazo:secret@postgres/wazo
 
 amqp:
   uri: amqp://guest:guest@rabbitmq:5672/

--- a/etc/wazo-call-logd.yml
+++ b/etc/wazo-call-logd.yml
@@ -2,8 +2,8 @@ debug: true
 rest_api:
   listen: 0.0.0.0
 
-db_uri: postgresql://asterisk:secret@postgres/wazo
-cel_db_uri: postgresql://asterisk:secret@postgres/wazo
+db_uri: postgresql://wazo:secret@postgres/wazo
+cel_db_uri: postgresql://wazo:secret@postgres/wazo
 
 celery:
   broker: amqp://guest:guest@rabbitmq:5672

--- a/etc/wazo-calld.yml
+++ b/etc/wazo-calld.yml
@@ -2,7 +2,7 @@ debug: true
 rest_api:
   listen: 0.0.0.0
 
-db_uri: postgresql://asterisk:secret@postgres/wazo
+db_uri: postgresql://wazo:secret@postgres/wazo
 
 bus:
   host: rabbitmq

--- a/etc/wazo-chatd.yml
+++ b/etc/wazo-chatd.yml
@@ -2,7 +2,7 @@ debug: true
 rest_api:
   listen: 0.0.0.0
 
-db_uri: postgresql://asterisk:secret@postgres/wazo
+db_uri: postgresql://wazo:secret@postgres/wazo
 
 bus:
   host: rabbitmq

--- a/etc/wazo-confd.yml
+++ b/etc/wazo-confd.yml
@@ -2,7 +2,7 @@ debug: true
 rest_api:
   listen: 0.0.0.0
 
-db_uri: postgresql://asterisk:secret@postgres/wazo
+db_uri: postgresql://wazo:secret@postgres/wazo
 
 bus:
   host: rabbitmq

--- a/etc/wazo-confgend.yml
+++ b/etc/wazo-confgend.yml
@@ -1,7 +1,7 @@
 debug: true
 listen_address: 0.0.0.0
 
-db_uri: postgresql://asterisk:secret@postgres/wazo
+db_uri: postgresql://wazo:secret@postgres/wazo
 
 enabled_asterisk_modules:
   # Remove error log from asterisk

--- a/etc/wazo-dird.yml
+++ b/etc/wazo-dird.yml
@@ -2,7 +2,7 @@ debug: true
 rest_api:
   listen: 0.0.0.0
 
-db_uri: postgresql://asterisk:secret@postgres/wazo
+db_uri: postgresql://wazo:secret@postgres/wazo
 
 bus:
   host: rabbitmq

--- a/etc/wazo-webhookd.yml
+++ b/etc/wazo-webhookd.yml
@@ -2,7 +2,7 @@ debug: true
 rest_api:
   listen: 0.0.0.0
 
-db_uri: postgresql://asterisk:secret@postgres/wazo
+db_uri: postgresql://wazo:secret@postgres/wazo
 
 auth:
   host: auth

--- a/etc/xivo-dao.yml
+++ b/etc/xivo-dao.yml
@@ -1,1 +1,1 @@
-db_uri: postgresql://asterisk:secret@postgres/wazo
+db_uri: postgresql://wazo:secret@postgres/wazo


### PR DESCRIPTION
why: constraint has been fixed upstream

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes database credentials to use the `wazo` Postgres user across the stack.
> 
> - Updates `POSTGRES_USER` in `docker-compose.yml` and all service `db_uri`/DSNs to `postgresql://wazo:secret@postgres/wazo`
> - Switches init scripts (`init-chatd`, `init-confd`, `init-dird`, `init-webhookd`) to `db_username='wazo'`
> - Changes Asterisk ODBC config (`etc/asterisk-res_odbc.conf`) username to `wazo`
> - Adjusts README SQL prompt to use `-U wazo`
> 
> No schema or application logic changes; config-only update affecting database connections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 737a7bd75b93db9ad5f245aba52762b4923136d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->