### PR TITLE
docker: pin rabbitmq to version 3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       - "5432"
 
   rabbitmq:
-    image: rabbitmq
+    image: rabbitmq:3
     env_file:
       - variables.env
     expose:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a single `docker-compose.yml` change that pins the RabbitMQ Docker image tag, with the main impact being potential compatibility differences when upgrading/downgrading between RabbitMQ major versions.
> 
> **Overview**
> Pins the `rabbitmq` service in `docker-compose.yml` from the floating `rabbitmq` image tag to `rabbitmq:3` to ensure consistent RabbitMQ major version across environments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c016a8446f88bcce00e2f02390ee8041575e6941. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->