### PR TITLE
TASK-504-pin-auth-port

### DIFF
--- a/etc/wazo-agentd.yml
+++ b/etc/wazo-agentd.yml
@@ -9,6 +9,8 @@ amid:
 
 auth:
   host: auth
+  port: 9497
+  prefix: null
 
 bus:
   host: rabbitmq

--- a/etc/wazo-agid.yml
+++ b/etc/wazo-agid.yml
@@ -11,6 +11,8 @@ dird:
 
 auth:
   host: auth
+  port: 9497
+  prefix: null
 
 confd:
   host: confd

--- a/etc/wazo-amid.yml
+++ b/etc/wazo-amid.yml
@@ -17,3 +17,5 @@ bus:
 
 auth:
   host: auth
+  port: 9497
+  prefix: null

--- a/etc/wazo-auth-cli.yml
+++ b/etc/wazo-auth-cli.yml
@@ -3,3 +3,5 @@ auth:
   password: secret
   backend: wazo_user
   host: auth
+  port: 9497
+  prefix: null

--- a/etc/wazo-call-logd.yml
+++ b/etc/wazo-call-logd.yml
@@ -13,6 +13,8 @@ bus:
 
 auth:
   host: auth
+  port: 9497
+  prefix: null
 
 confd:
   host: confd

--- a/etc/wazo-calld.yml
+++ b/etc/wazo-calld.yml
@@ -9,6 +9,8 @@ bus:
 
 auth:
   host: auth
+  port: 9497
+  prefix: null
 
 amid:
   host: amid

--- a/etc/wazo-chatd.yml
+++ b/etc/wazo-chatd.yml
@@ -9,6 +9,8 @@ bus:
 
 auth:
   host: auth
+  port: 9497
+  prefix: null
 
 amid:
   host: amid

--- a/etc/wazo-confd.yml
+++ b/etc/wazo-confd.yml
@@ -9,6 +9,8 @@ bus:
 
 auth:
   host: auth
+  port: 9497
+  prefix: null
 
 ari:
   host: asterisk

--- a/etc/wazo-dird.yml
+++ b/etc/wazo-dird.yml
@@ -9,6 +9,8 @@ bus:
 
 auth:
   host: auth
+  port: 9497
+  prefix: null
 
 service_discovery:
   enabled: false

--- a/etc/wazo-phoned.yml
+++ b/etc/wazo-phoned.yml
@@ -8,6 +8,8 @@ bus:
 
 auth:
   host: auth
+  port: 9497
+  prefix: null
 
 dird:
   host: dird

--- a/etc/wazo-provd.yml
+++ b/etc/wazo-provd.yml
@@ -6,6 +6,8 @@ rest_api:
 
 auth:
   host: auth
+  port: 9497
+  prefix: null
 
 amid:
   host: amid

--- a/etc/wazo-ui.yml
+++ b/etc/wazo-ui.yml
@@ -7,6 +7,8 @@ amid:
 
 auth:
   host: auth
+  port: 9497
+  prefix: null
 
 call-logd:
   host: call-logd

--- a/etc/wazo-webhookd.yml
+++ b/etc/wazo-webhookd.yml
@@ -6,6 +6,8 @@ db_uri: postgresql://wazo:secret@postgres/wazo
 
 auth:
   host: auth
+  port: 9497
+  prefix: null
 
 bus:
   host: rabbitmq

--- a/etc/wazo-websocketd.yml
+++ b/etc/wazo-websocketd.yml
@@ -4,6 +4,8 @@ websocket:
 
 auth:
   host: auth
+  port: 9497
+  prefix: null
 
 bus:
   host: rabbitmq


### PR DESCRIPTION
Why: the services only set `host: auth` and inherited the rest from their
defaults, which now point at the nginx internal entry point
(`localhost:80/api/auth`). This stack has no such entry point -- its nginx
listens on 443 only -- so the requests have to keep going straight to the auth
container.

The prefix matters as much as the port: wazo-auth-client defaults to
`/api/auth`, so pinning the port alone would send requests to
`auth:9497/api/auth/...` and get 404s.
